### PR TITLE
Migrate to webpack 3 (cont. 2)

### DIFF
--- a/webpack.config.prod.babel.js
+++ b/webpack.config.prod.babel.js
@@ -8,5 +8,6 @@ export default merge(baseConfig, {
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: true,
     }),
+    new webpack.optimize.ModuleConcatenationPlugin(),
   ],
 });


### PR DESCRIPTION
Add webpack.optimize.ModuleConcatenationPlugin in production build.
ref. [webpack 3 リリース内容まとめ - dackdive's blog](http://dackdive.hateblo.jp/entry/2017/06/20/200830)