### PR TITLE
Server side production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### https://raw.github.com/github/gitignore/ce62a06810c01a5071610ea70dcc417916029f7a/node.gitignore
 .DS_Store
+dist
 bundle.js
 bundle.js.map
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn start
+web: yarn run serve

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "heroku-postbuild": "yarn run build",
-    "start": "babel-node app.js",
+    "start": "babel-watch app.js",
     "build": "yarn run build:client && yarn run build:server",
     "build:client": "NODE_ENV=production webpack --config=webpack.config.prod.babel.js --progress --colors",
     "build:server": "babel app.js -d dist",
@@ -43,6 +43,7 @@
     "webpack-merge": "^4.1.0"
   },
   "devDependencies": {
+    "babel-watch": "^2.0.7",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "A boilerplate for developing Express app with React&Redux",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack --config=webpack.config.prod.babel.js --progress --colors",
-    "heroku-postbuild": "npm run build",
+    "heroku-postbuild": "yarn run build",
     "start": "babel-node app.js",
+    "build": "yarn run build:client && yarn run build:server",
+    "build:client": "NODE_ENV=production webpack --config=webpack.config.prod.babel.js --progress --colors",
+    "build:server": "babel app.js -d dist",
     "lint": "eslint src",
+    "serve": "node dist/app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,14 @@ babel-types@^6.25.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel-watch@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/babel-watch/-/babel-watch-2.0.7.tgz#584ad2af245ba96f88721213a9563631ba8fae48"
+  dependencies:
+    chokidar "^1.4.3"
+    commander "^2.9.0"
+    source-map-support "^0.4.0"
+
 babylon@^6.11.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
@@ -1077,7 +1085,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
+chokidar@^1.4.3, chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1208,6 +1216,10 @@ commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4443,6 +4455,12 @@ source-list-map@^0.1.7:
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
+
+source-map-support@^0.4.0:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.17.tgz#6f2150553e6375375d0ccb3180502b78c18ba430"
+  dependencies:
+    source-map "^0.5.6"
 
 source-map-support@^0.4.2:
   version "0.4.15"


### PR DESCRIPTION
ref. https://github.com/kmagiera/babel-watch

> Using babel-node or babel-watch is not recommended in production environment. For the production use it is much better practice to build your node application using babel and run it using just node.

I'll reference this repository:
https://github.com/babel/example-node-server